### PR TITLE
Reproducible analysis for APOE CS3 and CS4

### DIFF
--- a/main_text/6_AD_xQTL_genes/staging/Reproducible.ipynb
+++ b/main_text/6_AD_xQTL_genes/staging/Reproducible.ipynb
@@ -1,0 +1,1036 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1596ebc5-98f5-42a4-a34f-0facb76e8655",
+   "metadata": {},
+   "source": [
+    "# Reproducible analysis\n",
+    "\n",
+    "After merging sets sharing \"DeJager_Mic_ENSG00000130203\", \"Kellis_Mic_ENSG00000130203\", \"DeJager_Mic_ENSG00000130208\", \"Kellis_Mic_ENSG00000130208\", we can get a set with 60 variants that including both reported variants in CS3 and CS4."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b6bb4607-496a-4385-a960-ee4c1a08679c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "library(tidyverse)\n",
+    "variants <- c(\n",
+    "  'chr19:44938353:A:C', 'chr19:44939092:T:C', 'chr19:44939262:A:T', 'chr19:44939831:G:C', 'chr19:44940247:A:G',\n",
+    "  'chr19:44940390:T:C', 'chr19:44940660:A:ATTGTT', 'chr19:44941309:G:T', 'chr19:44943014:C:T', 'chr19:44945208:T:G',\n",
+    "  'chr19:44946027:T:G', 'chr19:44946776:C:T', 'chr19:44947615:A:G', 'chr19:44947671:T:C', 'chr19:44948185:A:G',\n",
+    "  'chr19:44948363:T:A', 'chr19:44949887:C:T', 'chr19:44949894:T:G', 'chr19:44949908:C:T', 'chr19:44950979:G:A',\n",
+    "  'chr19:44951106:G:A', 'chr19:44951502:A:G', 'chr19:44951509:G:A', 'chr19:44952201:G:A', 'chr19:44952844:G:A',\n",
+    "  'chr19:44952989:T:C', 'chr19:44953240:T:C', 'chr19:44953684:G:A', 'chr19:44953848:A:G', 'chr19:44953923:T:C',\n",
+    "  'chr19:44953968:G:A', 'chr19:44954036:C:T', 'chr19:44954049:C:T', 'chr19:44954062:G:A', 'chr19:44954120:G:A',\n",
+    "  'chr19:44954150:CA:CAAAAA', 'chr19:44954427:G:C', 'chr19:44962801:T:C', 'chr19:44963328:ATT:AT', 'chr19:44967657:CAA:CA',\n",
+    "  'chr19:44980181:A:C', 'chr19:44983921:C:T', 'chr19:44986934:A:G', 'chr19:44987312:A:G', 'chr19:44987378:T:C',\n",
+    "  'chr19:44987916:A:G', 'chr19:44989803:T:C', 'chr19:44992424:A:G', 'chr19:44993518:A:G', 'chr19:44996130:T:C',\n",
+    "  'chr19:44999110:TAAAA:TAA', 'chr19:45001091:C:G', 'chr19:44951028:TAA:TA', 'chr19:44972443:G:T', 'chr19:44978409:CA:CAAA',\n",
+    "  'chr19:44979627:T:C', 'chr19:44989301:G:A', 'chr19:45000581:CT:CTT', 'chr19:44957507:G:A', 'chr19:44967087:C:T'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "a4a98416-21d5-4a05-ba36-a9c5cc5eb46d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "TRUE"
+      ],
+      "text/latex": [
+       "TRUE"
+      ],
+      "text/markdown": [
+       "TRUE"
+      ],
+      "text/plain": [
+       "[1] TRUE"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "'chr19:44945208:T:G' %in% variants"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "39ffdf1e-49f0-45df-988b-433203174eea",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "library(tidyverse)\n",
+    "library(data.table)\n",
+    "library(vroom)\n",
+    "library(vctrs)\n",
+    "library(susieR)\n",
+    "library(matrixStats)\n",
+    "for(file in list.files(\"/home/xc2270/COLOCBoost/pipeline/error/pecotmr\", full.names = T)) {source(file)}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0c91d9f-b29d-4cfe-a2b9-2944dd183b8c",
+   "metadata": {},
+   "source": [
+    "## Loading GWAS sumstat information"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f28f5978-45ab-4fb4-90c7-2dad46b1fb9b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# - summary statistics\n",
+    "studies = c(\"AD_Bellenguez\", \"AD_Kunkle_Stage1_2019\", \"AD_Wightman_Full_2021\", \"AD_Wightman_Excluding23andMe_2021\", \n",
+    "                    \"AD_Wightman_ExcludingUKBand23andME_2021\", \"AD_Bellenguez_EADB\")\n",
+    "sumstat_path_list = c('/mnt/jast/hpc/gaowang/users/xc2270/colocboost/pipeline/sumstat/AD_Bellenguez_2022.sumstats.tsv.gz',\n",
+    "                      '/mnt/jast/hpc/gaowang/users/xc2270/colocboost/pipeline/sumstat/Kunkle_etal_Stage1_results.txt_file_1_hg38.sorted.txt.gz',\n",
+    "                      '/mnt/jast/hpc/gaowang/users/xc2270/colocboost/pipeline/sumstat/PGCALZ2full.hg38.sorted.txt.gz',\n",
+    "                      '/mnt/jast/hpc/gaowang/users/xc2270/colocboost/pipeline/sumstat/PGCALZ2sumstatsExcluding23andMe.hg38.sorted.txt.gz',\n",
+    "                      '/mnt/jast/hpc/gaowang/users/xc2270/colocboost/pipeline/sumstat/PGCALZ2ExcludingUKBand23andME_METALInverseVariance_MetaAnalysis.hg38.sorted.txt.gz',\n",
+    "                      '/mnt/jast/hpc/gaowang/users/xc2270/colocboost/pipeline/sumstat/EADB_core.tsv.gz')\n",
+    "column_file_path_list = c('/home/xc2270/COLOCBoost/pipeline/Bellenguez_new.yml',\n",
+    "                          '/mnt/vast/hpc/csg/data_public/GWAS_sumstats/GWAS_sumstat_column_mapping/Kunkle_stage_1.yml',\n",
+    "                          '/mnt/vast/hpc/csg/data_public/GWAS_sumstats/GWAS_sumstat_column_mapping/AD_Wightman_Full_2021.yml',\n",
+    "                          '/mnt/vast/hpc/csg/data_public/GWAS_sumstats/GWAS_sumstat_column_mapping/AD_Wightman_Excluding23andMe_2021.yml',\n",
+    "                          '/mnt/vast/hpc/csg/data_public/GWAS_sumstats/GWAS_sumstat_column_mapping/AD_Wightman_ExcludingUKBand23andME_2021.yml',\n",
+    "                          '/mnt/vast/hpc/csg/data_public/GWAS_sumstats/GWAS_sumstat_column_mapping/EADB.yml')\n",
+    "# Replace _regions with _meta_info[1] which is the association window region\n",
+    "n_samples = c('0','0','0','0','0','0') %>% as.numeric\n",
+    "n_cases = c('111326','21982','90338','86531','39918','20301') %>% as.numeric\n",
+    "n_controls = c('677663','41944','1036225','676386','358140','21839') %>% as.numeric\n",
+    "\n",
+    "gwas_meta <- data.frame(\n",
+    "    \"study_id\" = studies,\n",
+    "    \"file_path\" = sumstat_path_list,\n",
+    "    \"column_mapping_file\" = column_file_path_list,\n",
+    "    \"n_sample\" = n_samples,\n",
+    "    \"n_case\" = n_cases,\n",
+    "    \"n_control\" = n_controls\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0614c259-fd68-46ec-887a-2b5a02540068",
+   "metadata": {},
+   "source": [
+    "## Analysis in a larger region - EADB for reproducible analysis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "3d1a90fc-da53-49b5-989b-df24ca7634f9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1mRows: \u001b[22m\u001b[34m1\u001b[39m \u001b[1mColumns: \u001b[22m\u001b[34m4\u001b[39m\n",
+      "\u001b[36m──\u001b[39m \u001b[1mColumn specification\u001b[22m \u001b[36m────────────────────────────────────────────────────────\u001b[39m\n",
+      "\u001b[1mDelimiter:\u001b[22m \"\\t\"\n",
+      "\u001b[31mchr\u001b[39m (2): #chrom, path\n",
+      "\u001b[32mdbl\u001b[39m (2): start, end\n",
+      "\n",
+      "\u001b[36mℹ\u001b[39m Use `spec()` to retrieve the full column specification for this data.\n",
+      "\u001b[36mℹ\u001b[39m Specify the column types or set `show_col_types = FALSE` to quiet this message.\n"
+     ]
+    }
+   ],
+   "source": [
+    "ldblock<-load_LD_matrix('/mnt/jast/hpc/gaowang/users/xc2270/transQTL/APOE/in_Iris/ld_meta_file_apoe.tsv',\n",
+    "                         region = data.frame(chr='chr19', start=42346101, end=46842901))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "6edd1114-4017-4e3f-b23d-3e5730ce4c85",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "impute_opts=list(rcond = 0.01, R2_threshold = 0.6, minimum_ld = 5, lamb = 0.01)\n",
+    "qc_method='rss_qc'\n",
+    "association_window = \"chr19:42346101-46842901\"\n",
+    "sumstats_region_name_col = NULL\n",
+    "comment_string = NULL\n",
+    "extract_sumstats_region_name = NULL"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ba0f3c11-1548-4bda-b25c-0b89e19e2149",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "AD_Bellenguez_EADB\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "gwas = gwas_meta$study_id[6]\n",
+    "sumstat_path=gwas_meta %>% filter(study_id==gwas) %>% pull(file_path)\n",
+    "column_file_path=gwas_meta %>% filter(study_id==gwas) %>% pull(column_mapping_file)\n",
+    "n_sample=gwas_meta %>% filter(study_id==gwas) %>% pull(n_sample)\n",
+    "n_case=gwas_meta %>% filter(study_id==gwas) %>% pull(n_case)\n",
+    "n_control=gwas_meta %>% filter(study_id==gwas) %>% pull(n_control)\n",
+    "message(gwas)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "ac628087-592d-43f5-9cdd-4d49a969080a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Taking input= as a system command because it contains a space ('zcat /mnt/jast/hpc/gaowang/users/xc2270/colocboost/pipeline/sumstat/EADB_core.tsv.gz | head -1 && tabix /mnt/jast/hpc/gaowang/users/xc2270/colocboost/pipeline/sumstat/EADB_core.tsv.gz 19:42346101-46842901'). If it's a filename please remove the space, or use file= explicitly. A variable is being passed to input= and when this is taken as a system command there is a security concern if you are creating an app, the app could have a malicious user, and the app is not running in a secure environment; e.g. the app is running as root. Please read item 5 in the NEWS file for v1.11.6 for more information and for the option to suppress this message.\n",
+      "\n",
+      "Region chr19:42346101-46842901 include 36770 in input sumstats.\n",
+      "\n",
+      "42140\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "63.7703009697287"
+      ],
+      "text/latex": [
+       "63.7703009697287"
+      ],
+      "text/markdown": [
+       "63.7703009697287"
+      ],
+      "text/plain": [
+       "[1] 63.7703"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sumstat_path=gwas_meta %>% filter(study_id==gwas) %>% pull(file_path)\n",
+    "column_file_path=gwas_meta %>% filter(study_id==gwas) %>% pull(column_mapping_file)\n",
+    "n_sample=gwas_meta %>% filter(study_id==gwas) %>% pull(n_sample)\n",
+    "n_case=gwas_meta %>% filter(study_id==gwas) %>% pull(n_case)\n",
+    "n_control=gwas_meta %>% filter(study_id==gwas) %>% pull(n_control)\n",
+    "\n",
+    "#get summstats\n",
+    "rss_input <- load_rss_data(\n",
+    "  sumstat_path = sumstat_path, column_file_path = column_file_path,\n",
+    "  n_sample = n_sample, n_case = n_case, n_control = n_control,\n",
+    "  region = association_window\n",
+    ")\n",
+    "message(rss_input$n)\n",
+    "# Preprocess the input data\n",
+    "preprocess_results <- rss_basic_qc(rss_input$sumstats, ldblock)\n",
+    "\n",
+    "#if zscore =Inf, transform as the max value\n",
+    "max(preprocess_results$sumstats$z[!is.infinite(preprocess_results$sumstats$z)])\n",
+    "if(any(is.infinite(preprocess_results$sumstats$z))){\n",
+    "message(sum(is.infinite(preprocess_results$sumstats$z)),' variants have infinite zscore, exclude them')\n",
+    "preprocess_results$sumstats<-preprocess_results$sumstats[!is.infinite(preprocess_results$sumstats$z),]\n",
+    "preprocess_results$LD_mat=preprocess_results$LD_mat[preprocess_results$sumstats$variant_id,preprocess_results$sumstats$variant_id]\n",
+    "}\n",
+    "\n",
+    "# Perform Slalom quality control\n",
+    "qc_results <- summary_stats_qc(preprocess_results$sumstats, list(combined_LD_matrix=preprocess_results$LD_mat), n = rss_input$n,\n",
+    "                             var_y = rss_input$var_y,\n",
+    "                             method = qc_method)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "0cac89dd-f708-4e53-8aaf-4d61837925e6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       ".list-inline {list-style: none; margin:0; padding: 0}\n",
+       ".list-inline>li {display: inline-block}\n",
+       ".list-inline>li:not(:last-child)::after {content: \"\\00b7\"; padding: 0 .5ex}\n",
+       "</style>\n",
+       "<ol class=list-inline><li>12239</li><li>12240</li><li>12242</li><li>12247</li><li>12253</li><li>12260</li></ol>\n"
+      ],
+      "text/latex": [
+       "\\begin{enumerate*}\n",
+       "\\item 12239\n",
+       "\\item 12240\n",
+       "\\item 12242\n",
+       "\\item 12247\n",
+       "\\item 12253\n",
+       "\\item 12260\n",
+       "\\end{enumerate*}\n"
+      ],
+      "text/markdown": [
+       "1. 12239\n",
+       "2. 12240\n",
+       "3. 12242\n",
+       "4. 12247\n",
+       "5. 12253\n",
+       "6. 12260\n",
+       "\n",
+       "\n"
+      ],
+      "text/plain": [
+       "[1] 12239 12240 12242 12247 12253 12260"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pp_cos <- which( paste0(\"chr\", preprocess_results$sumstats$variant_id) %in% variants )\n",
+    "pp_cos %>% head"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "4b496b87-4db2-4a71-934f-04f7a36fcd57",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing single LD matrix...\n",
+      "\n",
+      "IMPUTATION REPORT\n",
+      "\n",
+      "\n",
+      "Variants before filter:                    4166\n",
+      "\n",
+      "Non-imputed variants:                      0\n",
+      "\n",
+      "Imputed variants:                          4166\n",
+      "\n",
+      "Variants filtered because of low LD score: 785\n",
+      "\n",
+      "Variants filtered because of low R2:       1800\n",
+      "\n",
+      "Remaining variants after filter:           2366\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# pp_cos <- which( qc_results$sumstats$variant_alternate_id %in% cos_idx )\n",
+    "sumstats_obs <- qc_results$sumstats[pp_cos, ]\n",
+    "qc_results$sumstats <- qc_results$sumstats[-pp_cos, ]\n",
+    "impute_results <- raiss(ldblock$ref_panel, qc_results$sumstats, ldblock$combined_LD_matrix,\n",
+    "              rcond = impute_opts$rcond,\n",
+    "              R2_threshold = impute_opts$R2_threshold,\n",
+    "              minimum_ld = impute_opts$minimum_ld, lamb = impute_opts$lamb)\n",
+    "ll <- list(summstats=data.table(impute_results$result_filter),\n",
+    "           sumstats_obs = sumstats_obs,\n",
+    "           outlier_number=qc_results$outlier_number)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "aea949ca-ab8e-4958-9d6b-765cd8ec52ac",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       ".list-inline {list-style: none; margin:0; padding: 0}\n",
+       ".list-inline>li {display: inline-block}\n",
+       ".list-inline>li:not(:last-child)::after {content: \"\\00b7\"; padding: 0 .5ex}\n",
+       "</style>\n",
+       "<ol class=list-inline><li>42</li><li>3</li></ol>\n"
+      ],
+      "text/latex": [
+       "\\begin{enumerate*}\n",
+       "\\item 42\n",
+       "\\item 3\n",
+       "\\end{enumerate*}\n"
+      ],
+      "text/markdown": [
+       "1. 42\n",
+       "2. 3\n",
+       "\n",
+       "\n"
+      ],
+      "text/plain": [
+       "[1] 42  3"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table class=\"dataframe\">\n",
+       "<caption>A data.frame: 6 × 3</caption>\n",
+       "<thead>\n",
+       "\t<tr><th></th><th scope=col>variant_id</th><th scope=col>z_imp</th><th scope=col>z_original</th></tr>\n",
+       "\t<tr><th></th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "\t<tr><th scope=row>19:44939092:T:C</th><td>19:44939092:T:C</td><td>9.730234</td><td>9.361135</td></tr>\n",
+       "\t<tr><th scope=row>19:44939831:G:C</th><td>19:44939831:G:C</td><td>9.749849</td><td>9.337308</td></tr>\n",
+       "\t<tr><th scope=row>19:44940247:A:G</th><td>19:44940247:A:G</td><td>9.552911</td><td>9.281704</td></tr>\n",
+       "\t<tr><th scope=row>19:44941309:G:T</th><td>19:44941309:G:T</td><td>9.536545</td><td>9.277907</td></tr>\n",
+       "\t<tr><th scope=row>19:44943014:C:T</th><td>19:44943014:C:T</td><td>9.491535</td><td>9.180963</td></tr>\n",
+       "\t<tr><th scope=row>19:44945208:T:G</th><td>19:44945208:T:G</td><td>9.576777</td><td>9.652020</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "A data.frame: 6 × 3\n",
+       "\\begin{tabular}{r|lll}\n",
+       "  & variant\\_id & z\\_imp & z\\_original\\\\\n",
+       "  & <chr> & <dbl> & <dbl>\\\\\n",
+       "\\hline\n",
+       "\t19:44939092:T:C & 19:44939092:T:C & 9.730234 & 9.361135\\\\\n",
+       "\t19:44939831:G:C & 19:44939831:G:C & 9.749849 & 9.337308\\\\\n",
+       "\t19:44940247:A:G & 19:44940247:A:G & 9.552911 & 9.281704\\\\\n",
+       "\t19:44941309:G:T & 19:44941309:G:T & 9.536545 & 9.277907\\\\\n",
+       "\t19:44943014:C:T & 19:44943014:C:T & 9.491535 & 9.180963\\\\\n",
+       "\t19:44945208:T:G & 19:44945208:T:G & 9.576777 & 9.652020\\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "A data.frame: 6 × 3\n",
+       "\n",
+       "| <!--/--> | variant_id &lt;chr&gt; | z_imp &lt;dbl&gt; | z_original &lt;dbl&gt; |\n",
+       "|---|---|---|---|\n",
+       "| 19:44939092:T:C | 19:44939092:T:C | 9.730234 | 9.361135 |\n",
+       "| 19:44939831:G:C | 19:44939831:G:C | 9.749849 | 9.337308 |\n",
+       "| 19:44940247:A:G | 19:44940247:A:G | 9.552911 | 9.281704 |\n",
+       "| 19:44941309:G:T | 19:44941309:G:T | 9.536545 | 9.277907 |\n",
+       "| 19:44943014:C:T | 19:44943014:C:T | 9.491535 | 9.180963 |\n",
+       "| 19:44945208:T:G | 19:44945208:T:G | 9.576777 | 9.652020 |\n",
+       "\n"
+      ],
+      "text/plain": [
+       "                variant_id      z_imp    z_original\n",
+       "19:44939092:T:C 19:44939092:T:C 9.730234 9.361135  \n",
+       "19:44939831:G:C 19:44939831:G:C 9.749849 9.337308  \n",
+       "19:44940247:A:G 19:44940247:A:G 9.552911 9.281704  \n",
+       "19:44941309:G:T 19:44941309:G:T 9.536545 9.277907  \n",
+       "19:44943014:C:T 19:44943014:C:T 9.491535 9.180963  \n",
+       "19:44945208:T:G 19:44945208:T:G 9.576777 9.652020  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "z_imp <- impute_results$result_filter %>% filter(paste0(\"chr\", variant_id) %in% variants ) %>% pull(z)\n",
+    "names(z_imp) <- impute_results$result_filter %>% filter(paste0(\"chr\", variant_id) %in% variants) %>% pull(variant_id)\n",
+    "z_original <- sumstats_obs %>% pull(z)\n",
+    "names(z_original) <- sumstats_obs %>% pull(variant_id)\n",
+    "ov <- intersect(names(z_imp), names(z_original))\n",
+    "imp_data <- data.frame(\n",
+    "    variant_id = ov,\n",
+    "    z_imp = z_imp[match(ov, names(z_imp))],\n",
+    "    z_original = z_original[match(ov, names(z_original))]\n",
+    ")\n",
+    "imp_data %>% dim\n",
+    "imp_data %>% head"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "4934505e-318d-4d0d-adce-9a7b68d1ec01",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA0gAAANICAMAAADKOT/pAAADAFBMVEUAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACz\nMPSIAAABAHRSTlMAAQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyAhIiMkJSYnKCkq\nKywtLi8wMTIzNDU2Nzg5Ojs8PT4/QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW1xdXl9g\nYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXp7fH1+f4CBgoOEhYaHiImKi4yNjo+QkZKTlJWW\nl5iZmpucnZ6foKGio6SlpqeoqaqrrK2ur7CxsrO0tba3uLm6u7y9vr/AwcLDxMXGx8jJysvM\nzc7P0NHS09TV1tfY2drb3N3e3+Dh4uPk5ebn6Onq6+zt7u/w8fLz9PX29/j5+vv8/f7/qVjM\n+gAAAAlwSFlzAAASdAAAEnQB3mYfeAAAIABJREFUeJzt3XlgFOXdwPFncwMCAQIieEBFRA5B\nQMETUETkEpQqtop4tCreiBzVYlRArUotWkRBRERRatVyCHjQQBVBjvIqlyhyhUNiIAcJSfZ4\n3p3dTQwImybzy06ezffzR2ayO9n5le7XZGd3Z5UCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgKqnfSfAKO0jW0idC/oN\n7tuxZhlbddaAYTpHJKCgvss8gX0WLbwo7HYX6YQITQSISNDh79KixuiCJZPGjhj7t2Ue723h\nNiQkGCaSITX3fN6oeHX1kVPCbElIMEwkQ7pTn16y3kqH+5VESDBMJEMaW/TLuss7NsyWhATD\nRDKkYbpNyXonfUuYLQkJholkSCfn/7d1aLXLdzkpYbYkJBgmokfthnn05vdf+dvUD7fpgmvD\nbUhIMExEQ1Id3/458DzSvmktw25HSDBMZEPyO7nd+e0aHu+Kk558psS7hASzRDykEFeL+sdc\ncvKCT0ts0rUdmQqoIKdCStKpYa69U58UqUEACYQECCAkQEAkQ/rjml+sJSREk0iG9GddWFCC\nkBBNIhlSk8wpJev8aYeoEtHHSIP1oOJVQoJBat39Ztr0W8I9uRnZgw0zD54WWiMkmKPVtn2v\np751aF3jE28S2ZDiUpJCa7FjLgmzHSGhCkn8/l+1/IuUFf9xnXAbpw5/h0dIqEJuzqwTWJ7h\n7nbCbQgJKMNr74VWvnr0hNsQElCGd18JrSz8ywm3ISSgDM9/GlrZet8JtyEkoAyXuDsEln3d\nzU+4DSEBZXlnT2+Xir0x6+kTb0JIQFkSJxflbMzPHxdz4k0ICShb437De9V3XfrAkzee4MSm\nhAT8b5qvcu/dl++eeNwrCQn4n5y0bXPht9On79ZzjnctIQFlOW3aNz8u/TDDHTjN9lt6wHE2\nISSgDA97vbt/KNCeNwPf1fRsOs42hASEN9C37WR/KQd1enzg+wO+43xQHiEB4W33nt8mQanV\n2n299W38Ed3k1xsREhDWGdqttXthywk+98vW99cXFh7nHX6EBIQT82/9bYuGVyzKuqxIW68C\nvyRzy4LjbEZIQDg3HdZb/QvXB19N1u4FM1b5vs079zibERIQzpLJ3/l6+Jdn67W+LHfmnsKd\nlx1vM0ICwtl+S1/v4UEuVcPtm5/Q86GHeh7/FCiEBITz/R3q1iKfO9enVySG2YyQgHDmvqNU\nyn0ffDLHe4KXqwYREhBOD8/V1qLOmvfDbkZIQFip7mlDrh69fVOjsFsREhBe74/35q99oox7\nJCEBAggJEEBIgABCAgQQEiCAkAABhAQIICRAACEBAggJEEBIgABCAgQQEiCAkAABhASE1B36\nl0kPX/HA5FHHPb1JeIQEBPXPPJTl1dq9YXXR5w3L+8OEBAR0Llzk9Xfkt7vX2i/DfDjfcRES\nELBwocen9Reb/b+T0s8+PLCcP01IgCWmYIHWH2xQaqjWmY988Eo5f5yQAEuyTtdZzyxW6lSt\n9y2eHP6cQb9GSIAlpiC3aPOIb5Tq6nNnr/4nv5GACpl/xJ3d3tdJTV3ly/4099py/jQhAQEd\nvbrod29v/6v7Y12wYyVH7YCKeVRr348FOt+nfcvDnw3yOAgJCHJ97fFq7fXpgiGucv8wIQEh\n9Zd5MvPyvP9tUIGfJSSgmKvn4zMf71n+X0eKkAARhAQIICRAACEBAggJEEBIgABCAgQQEiCA\nkAABhAQIICRAACEBAggJEEBIgABCAgQQEiCAkAABhAQIICRAACEBAggJEEBIgABCAgQQEiCA\nkAABhAQIICRAACEBAggJEEBIgABCAgQQEiCAkAABhAQIICRAACEBAggJEEBIMF/ieT1OcXgE\nQoLpakw6ogv1uq6ODkFIMFzsqszZNzVs80bBpU5OQUgwW9PNevuKQ4fvU69ucjk4BiHBaDU2\nHZrp/610R8GdTX0dHJyDkGC0J7KyVozvH6vuPVTj5+scnIOQYKzk6QXaknNkzek1C6483NfB\nWQgJpmpTqIN8vo3fxu8a723s4DCEBEN18OgS3uxheTvfcXIaQoKZ6h0MJuT7xvqddHiXb12y\nk+MQEsz0aJYVUNaNBdrtX2rf0gRHxyEkmOnzDf6Qig6oi7xe6zdTepyz4xASzLRukT8fj+9y\n9UOuFdJ4h8chJJjp41etP+327O+ZH3is1MzhcQgJZrpnf5b12OhQ8JBDmtPjEBLMlLRxr7vk\n8HfmmU6PQ0gwVNN1+kioox0znr3J4XsMIcFY7xQs+3JvTo6vaNs/Fh7Yf7mjsxASjOW6a7f/\n19H37ltcSiX+9fDZTs5CSDBZ4/Nq//BEcPXTt5wchJBgtjN16EDDzfudHIOQYLYuukZw5QqP\nk2MQEszWXJ8VXLllr5NjEBIM993EwMKV9oaTUxASDDfIPTxGqVpTsx19UpaQYLrb8/Z8vDR7\n18WODkFIMF7Doc+mXpvk7AyEBAggJEAAIQECCAkQQEiAAEICBBASIICQAAGEBAggJEAAIQEC\nCAkQQEiAAEICBBASIICQAAGEBAggJEAAIQECCAkQQEiAAEJClVLv9hdfuedUp6coP0JCVdL/\n4J4P3v2+4G6n5yg3QkIVcl7hE3FKuW5zD3J6kvIiJFQhH34QXD6z0dk5yo+QUIXkhn4TtdWn\nODtIuRESqo5EfWFwpYFu5+wk5UZIqEIO/Ta47KAbOTtIuRESqpA5i4PLl9Y6O0f5ERKqkFaH\nX66lVPwo95VOT1JehISq5LLd2cs/y8i6wek5yo2QUKUkDXxs/A3JTk9RfoQECCAkQAAhAQII\nCRBASIAAQgIEEBIggJAAAYQECCAkQAAhwRGnD7rr8tpODyGIkOCAum97D24qzDLvHCcnREiI\nuLg267f/bc7S16YVDHd6FDGEhAiLHXtIa+3L/WFj3pbcOk5PI8WBkC6dsWxRauOwmxBSFJt+\n8I6lvvy13o++PbijaKDT00iJZEjjPIn+r6O0JbNLuC0JKXp181zgKiiqr8b+nDw1Uz/p9DhS\nIhlSqk5Sqp1vz/VNWo3O25kQZktCil5T56nL9DdKJeYMStjlneb0OFIiHtKTwTMu3an7hNmS\nkKLXJxPUqMKf45RaPVLN0+OdHkdKxEOa8VNgvZ4eecy1jebMLbGGkKLWvEkq9UDBa/Fq471n\nHPRe5/Q4UiIe0oT9gfVE34hjrq09/pkSiwkpav15Q8ywg/kZ2972fZZ3uMjAszMcX8RD6qFb\nWOt99LVhtuRPu+jVJDe1Yd7mH6bsz5r2of6r09OIiWxIS9+f/vyh+f7VgT9l1gqzJSFFsf55\naf8q2qu9P7h9K5yeRU4kQ7p/f4F15HuDUq6CosHhtiSkaHbWlNWHCnWO78gzcU6PIifCT8gm\nNm7VxTpq91j7sJsRUrSL73Bdl6j6/5iXCAECCAkQQEiAAEICBBASIICQAAGEBAggJEAAIQEC\nCAkQQEiAAEICBBASIICQAAGEBAggJEAAIQECCAkQQEiAAEICBBASIICQAAGEBAggJEAAIQEC\nCAkQQEiAAEICBBASIICQAAF2Qpp+lAGCUxESDGMnJH2UVLmhCAmmsRNSq6OkCE5FSDCM2GOk\npzvL3E4AIcEw9kOKq5ucnFyvc9ZokXmCCAmGsRtS2+Xe0GOkgUITWQgJhrEZUvz3nlXbDnyy\nVS+6UWoiCyHBMDZD6q97qfELlLp8Sx+piSyEBMPYDOmhgyoQkup+uKHQRBZCgmFshjQiQ6lx\ny6219FtlBgogJBjGZkiDdTv1x2zrXp8+SmgiCyHBMDZDqpV98IKz9ZLunSbra6VGUoQE49g9\n/H1VxkXqFevo99p4oYkshATD2H5CNj5Rua579bXhSTLzBBESDMPbKAABtkNq3Ou6wQGtZQYK\nICQYxm5If/HyNgrAbkgX6G8mjHgwoKvUSIqQYBybId27K1FqktIICYaxGdLIRVKDHIWQYBib\nIfXY7pKapDRCgmFshuR6//nK+NuOkGAYmyF1ez5r/+LZAbxECNWYzZBSOYsQoGyH1OCMU4vV\nkRpJERKMw0uEAAF2QpraXPWbWqKf4FSEBMPYOtNqVx4jAQG2zrSapFI40yqgeIwEiLAZ0tl9\neodcdVkTqZkICcaRex5J66XNhIYiJJjGZkjtH9mX+faTT8zK2PnohIW+jbFCUxESDGMzpJil\ncwN3+VrvzVVqqL5KZihCgmlshtQnv3ZwpXbexcp1+GGJkRQhwTg2Qxq9r3htlz+ifY/YHyiA\nkGAYmyEN112CK231g6qjvl5iJEVIMI7NkM4ozHzs8rZtLhu5z9f23APZUnd/QoJh7D4h+7vc\n4KHvohHq3MzeQkMREkxj+5UNDW6ZNOutl+4+Tam4mjIjKUKCcXiJECCAt1EAAngbBSCAt1EA\nAniMBAiw+xmy38RJTVIaIcEwNkO6y5ssNUlphATD2Ayp7ppZtaVGKYWQYBi7Z1p9ekv+srmc\naRXVHWdaBQTYDKlhy2acaRXg8Dcgwf6HMY+cm5Y2517Zg3eEBMPYDalvTvAR0v4uQgMFEBIM\nY/fw96F997Rt1OjcERm7k6RGUoQE49gM6XrdKbjSWQ+QGCeEkGAYmyGN2Vu8tnOU/WFKEBIM\nYzOkR7KK13aPtD9MCUKCYeye106HXtBwlb5aYpwQQoJhbIYU/0P+iwM6n3/NS0e+i5caSRES\njGP38HfrrcHD35taCg0UQEgwjO0nZOOveXbWm8/0lX1bEiHBMKIvERo7Q+iGCAmGEQ3pxc+E\nboiQYBhCAgQQEiCAkAABhAQIICRAACEBAggJEEBIgABCAgSIhjTi70I3REgwjM2QWvZJDK2N\n6G5/mBKEBMPYPtPq+nOCa+mp9ocpQUgwjN2Q3J78uwJr6akC0xQjJBjGbkjpF+/QHzZQhITq\nzXZIqu4cnX45IaF6sx+SUrfkep+JT08VmSeIkGAYiZDUmav014dSReYJIiQYRiQkFTfRy+cj\noTqzGdK5g0Ir3T8YIjBNMUKCYURe2dC0R8cY+7dSCiHBMLZCSnjyY+vrG1rrjWeJjaQICcax\nFdJCvc2l1Hj91fBn8zfFyg1FSDCNnZAu1NP89SRmfVdTqSG6p+BUhATD2Anpbo/1Acy9tPWB\nLgneEWIzERKMYyeknUVf+P2oN1gLz84v5KYiJBjGTkjzCh702/uT9fXBonkPyk1FSDCMnZCG\n6vpKNfW8bq031EPFZiIkGMdOSC08Mxu1/lJfaq1P1q3FZiIkGMfW4e+XrE9GesG/0vlz/YHY\nSIqQYBxbIblufP3vgdcIXeWeXUNqIgshwTAyJz9JaqSe7ixwO8UICYaxH1Jc3eTk5Hqds0aL\nzBNESDCM3ZDaLvcGP0RWDxSayEJIMIzdTzX/3rNq24FPtupFN0pNZCEkGMZmSP11LzV+gVKX\nb+kjNZGFkGAYmyE9dFAFQlLdDzcUmshCSDCMzZBGZCg1brm1ln6rzEABhATD2AxpsG6n/pht\n3evTRwlNZCEkGMZmSLWyD15wtl7SvdNkfa3USIqQYBy7h7+vyrhIvWId/V4bLzSRhZBgGNtP\nyMYnKtd1r742PElmniBCgmFEPx9JDCHBMDZDGjo1tBKzq6/ANMUICYaxe6bV9aGVkwo4ZwOq\nMVshrVyZnrcyYNUBPUxsJkKCcWyFNG5+pq8g6MCsBLmhCAmmkfrTThYhwTA2Q2pScqYG3tiH\n6ow39gECeGMfIIA39gECeGMfIIA39gECeGMfIIA39gECeGMfIIA39gECeGMfIIA39gEC7ITU\nu7Q+ZwtORUgwjJ2Q9FFS5YYiJJjGTkiP+T2Tu3FK6lMzdmaMbC84FSHBMHZfa/f1hMAydvIq\njtqhGrMZ0oD82OBKzcL+EuOEEBIMYzOk0buL13g/EqozmyHdozsFVy7V90qME0JIMIzNkJoV\nZqb27tS5d+pBdwupkRQhwTh2n5C9Pjt48Dv/NqGBAggJhrH9yobkm1+YNevFOxrJjBNCSDCM\n6EuExs4QuiFCgmFEQ3rxM6EbIiQYJuIhuU5KqVXmRoQEw0Q2pMZPrM7TWud88UidsNsREgwT\n0ZB65ejD65bMW/J/hXr/+eE2JCQYJpIhJR/cNSAusJZ0c0Z6uD/wCAmGiWRIv9ddS9av1IPD\nbElIMEwkQxpb9Mt6rHfMMdeetnlbiQxdW24qoPJFMqR79C9P256qhx9zbfzQP5aYzW8kmCWS\nIbXWbxd/Glmtf/lahtmSP+1gmIgetfu7Tn/l3hsGDXng9Qw9MdyGhATDiIY04u/hr3fdvzt0\ngoett4TdkJBgGNshnTv+o+Vp7z965v+2tavdDfc9ct9vW5WxGSHBMHZDGucL/opxPyA0UAAh\nwTA2QzrXt+63Z6U0anPHTu85UiMpQoJxbH8+UnJw5Uyf5K8kQoJhbIY06t/Fa9sfsT9MCUKC\nYeyejuv70Epi7pUC0xQjJBjG7gkiVzwVeI416dUlMTIDBRASDGMzpB6vFGYufmvm4kM5b0yb\nPn36AKGpCAmGsRlSauWcSJ+QYBibITVu3aq0FKGpCAmG4YPGAAGEBAiwG1L7Gas3bwng3N+o\nxmyG1OSgLtibHjBCaiRFSDCOzZBuP3KVS2qUUggJhrH7EqGlUoMchZBgGJsh9d4kNchRCAmG\nsRlSzOKJNaVGKYWQYBi7R+1a/5S99rOAoUITWQgJhrEZUtMs8ZcHWQgJhrEZ0l2e2xtKvuw7\nhJBgGJshjVkuNchRCAmGsRnSNf+VGuQohATD2Awp7rMHKuEvO0KCaWyG1G1S9s6FswOulRpJ\nERKMI/fGvlShiSyEBMPYDKnBGacWC/9hluVDSDAM70cCBNgJaWpz1W9qiX6CUxESDGMnJN2V\nx0hAgJ2QWiWpFPkTn1gICYbhMRIggJAAAYQECCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQE\nCCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQE\nCCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQE\nCCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQE\nCCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQE\nCCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQE\nCCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQE\nCCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQE\nCCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQECCAkQIADIV06Y9mi1MZhNyEkGCaSIY3zJPq/\njtKWzC7htiQkGCaSIaXqJKXa+fZc36TV6LydCWG2jFhICfGR2Q+iXcRDelJfaK3fqfuE2TIy\nISX8aZO7aMPIuAjsCtEu4iHN+CmwXk+PDLNlREKquXzvyMu6jz7waWLl7wvRLuIhTdgfWE/0\njQizZURCmrDrFGtx+r4/Vf6+EO0iHlIP3cJa76OvDbNlJEKK+ekPwZUHdlT6vhD1IhvS0ven\nP39ovn914E+ZtY69uma9Eg9FIKTGulVwpaOuU+k7Q7SLZEj37y+wjnxvUMpVUDT42GvP9OhS\nalbeGK6+LyyYMf6iZrpl8PsOum7l7QzVRISfkE1s3KqLddTusfa/vu7cTiVu1eEOjttz0qKC\nT77zae0pGB684K49lbYvVBtV8yVCF1ViSO9s7brjq54n//PnA0VnWt832jm+0vaFasOBkBJ6\n/qasTSoxpLN8F8xYk6RU0q5xR7Jua3vuH3as/NWjNaC8HAipsU4ta5NKDOmO7fG5gQOGL394\nZ/4+rfdOrFFZu0I1Uu1Cenj1aTrwJ13qv9vreg3qV9Z+UL1Uu5BuzGisW1srs2Z3qcxjg6he\nql1IKUd+v/NB/7Jpzg2PbaqsnaDacSCkOtMHlLVJZR61G3t4zs/nqI4blnfKvrvSdoLqpvod\n/lZj84u8ufrr1/NnxlTeTlDNVMOQVMo176zft3Ph9ZW4C1Q31TEkQFw0h9Ru6INX8XpURET0\nhtTkU71jXV7WbQLjAGWJ2pBqbFrR0v8/7/6imyUGAsKL2pBG7An+VTfqAA+3UPmiNqS0p4PL\nOu5L7d4UUKaoDWlr6I3kat8QuzcFlClqQ/p6THAZn9/b7k0BZYrakJ5b6wosBxUm2x4HKEvU\nhnRqzt+sMz922PecwDxAGaI2JNU9Y/uMF5a4Z3NSYkRA9Iak6j8wc/5feti/HaBsURwSEDmE\nBAggJEAAIQECCAkQQEiAAEICBBASIICQAAGEBAggJEAAIQECCAkQQEiAAEICBBASIICQAAGE\nBAggJEAAIQECCAkQQEiAAEICBBASIICQAAGEBAggJEAAIQECCAkQQEiAALNCavX08nX/6Bnh\nYYCyGRXSCK/bm+nW6+tHeh6gDCaFdI3HMyJJqT/5tvIpfKhiTApp7ZGHA8up7jsiOw5QFoNC\nquUrrBW6dlGE5wHKYFBIp+jdwZWWemNkxwHKYlBICUW5rsBKH89/IjwPUAaDQlKLfIEj365F\n2RMjPA9QBpNCal2Uc75SKW8U5jaJ+ERAWCaFpC47rHMzfYVZPSI9D1AGo0JScaPSNn8+pmGE\npwHKZFZIQBVFSIAAQgIEEBIggJAAAYQECCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQECCAk\nQAAhAQIICRBQNUPqrAHDdHa6muNp3ylSpm++yVy36z87PYINn69wegIbRureR9+R2jvdjMPG\nLXN6Ahtq6fOdHsGGqe84PYENLTWnsjoKITmGkKIJITmGkKIJITmGkKIJITmGkKIJITmGkKIJ\nITmGkKIJITmGkKIJITmGkKIJITmGkKLJmE+dnsCGRK/JL0yZPNPpCWxo5ktxeoSqpWZjpyew\n4zdOD2BHcn2nJ7DD6H96AAAAAAAAAAAAAAAAAAAAAAAAVFRC9yAj3yHX7MKWTo9QURcE/9m7\nOT1HBTTr3iC0VvO8znUdHaUKaRH6LIHPnB6k/Dqs88/9Qw+nx6iY9OA/u8fpOcrNdd8R3S+w\nFjMxT+ui15IcHqiK6Kxn9bZUyQ/lCOuUjEP3Xjx0d34bpwepkMPrA//svZyeo7xOWexeHwpp\ngp7Xu8fr+k2HJ6oieuoHnR6hgl7Q/f1fO+j3nB6kIuL0R06PUDEvbe86JhhSSsHqGP/iI19r\nh0eqGgbrYU6PUEE/7nVZi6/zTPx0wxQ90+kRKqZvXRUKaai+01r00Y85O1EVcYceeHr/35/n\n9BjlV0cvCCyn6LYOT1IRLfSLyT1v7m7ifwOKQ5oU/Iy+Rvp9Z8epIh7WX3j8D3q/PNXpQcqr\ntX4tsHxMX+3wJBXRSa/P8v+z777M6UEqIBTS3OCZ7VzuVc6OU0U8pdcNan7+bL0+1ulJyqmz\nnhxYPqwHOzxJRVyhD9x5TuvHCnObOz1J+YVCWqCDpxPL3eDoNI5bssUvVtVMibO+WxQ6EmOO\nDnpKYDlaD3B4koqIT6lhLUbr552epPxCIX2kGwW+PbLO0Wkc93aaX8mvodv1n50cpgJO03MC\ny2f1JQ5PYsOZ+nOnRyi/UEiv67OtRU0Tn4KsPEONC8l1OPhfwnm6QRlbVmGnGxzSqOCfAh31\nS86OU0U8tyjwzPRU8x5pzPNYB0hq56xxepCKGLako7UYol92epLyC4XUUU+1Fo8b96Cgcjyv\npyQodY17bw2nJymvXnpekoqdoW92epCK6KdXpih1znavgU88hEJSKwq7+x+q5nwX5+w4VUSt\nr/RPy77XBy9yepDym6QP/Dtdz3Q5PUeFTNZ5X64v8t7r9BzltWzlyl16y8qVqUq13O9bvcJz\nqKPTI1URsUOmL/5wbCOnx6iI3jOXvDXI6SEq6uKX5i98zrznkj9JC3rUv54ybv6Cp/iYJAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACw6V3duJw/4VlZ1hYntcsd\nforgHoEqb8CYWuX8iWNCci2+4Ojr68/waL9lZ4rtEYhCx4TUUvc++vrF3icvyRn+uHtLfASH\nApzVunuCat1NudpcUNf/3dmda1sXtvVf0OrCX/91Vq9La1copPgWXZvF+pftHtejutctdUGK\nfkeprJ7qKT1Qdeke0KniewTMYD1ieVO32Vik84f95r9F+sjt/gvf1122eLXvvaSjt53o1vr7\n89xWSA/85P/rbccApRZYf8ZdUuqCU/W0QEj1z4lRP+iANRXeI2AI6279ul55ZUy7zOxVg+Oa\n/VhYz7rwxyHxDV7VLxy16TC95uKz7vnOCulandatZZ+t7laqVqq+Ljm21AUxGT+3skKynN7C\n7209oaJ7BExh3a2n60f9azP1S/6v43VP68Ln/atx+w7Fld50tbep/+tD2h9Sr4kt/Ks36DFK\njQk8Rip1wQ3uI3OO/K7kp67wrTrqVsqzR8AUwbu1/28zNVEP9n8drn9rXXiFdd0HulWpLRM9\n31iL5jrwGKnu+Zf3vF9PKg6p1AXqwvmFWm9/sm7g4gZ7co45fPe/7xEwRvBufZZ/LVVf6v96\nhx5iXdjSum6K7lZqyzP0ImsRa4VUf65HFx7O1y8Wh1TqAr9aOQt36W3J1upHemiF9wgYI3i3\ntv4uSw38lgjdrU+3rntuNQUAAAABt0lEQVQ5+GsipIWeZy1cPn9I8/RzJyvV9ZeQSl1gyeoZ\n+4Ke6F+52zqGV9E9AsY4wd26vXXdbF36wPXJepm1SPH/Rkr2/Z+12q8kpNIXnKECR+1isz9R\n6pz87XUrvkfAGCe4W99qXbfeW7v0ptkZLv/X/v6QztAfWhe8URJSqQte080DIcXkfa4S13su\nsrNHwBQnuFt/01CpvvqzYzYdrtRJK70rVVzBjgSlblyv31TqQX2zKn3B1fqzZH9IrnF6tHpR\nj7O1R8AUJ7hbv7j/vfmFeR2P2rRVtm/lP/e/kLFKqRf0N69+sbPZwfxpKd10xvyBpS94Wmct\nLfr6R51Wo4XPO2e2paJ7BEwxLq2+eiTNeoJoWFo7/9e+aZdbd+um17y9ZMo5x2zbYvKSuTer\nd19TyvWHufNTG6qr57+TrO5d+FbXoy7oOOlD95pZN8WqFmkhFd4jYLJ39an2biD0yoYI7hGo\nemzfrS+pF+k9AlVPyd365IG/aFrx2yv7ZggJUWhcWsPgSh/PL66v+O2VfTMlewQAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAICI/weTnXIoTHId+wAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "plot without title"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "height": 420,
+       "width": 420
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot(imp_data$z_imp, imp_data$z_original)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "51a46926-e311-46c8-ab52-8003bcca7333",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "TRUE"
+      ],
+      "text/latex": [
+       "TRUE"
+      ],
+      "text/markdown": [
+       "TRUE"
+      ],
+      "text/plain": [
+       "[1] TRUE"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table class=\"dataframe\">\n",
+       "<caption>A data.frame: 1 × 3</caption>\n",
+       "<thead>\n",
+       "\t<tr><th></th><th scope=col>variant_id</th><th scope=col>z_imp</th><th scope=col>z_original</th></tr>\n",
+       "\t<tr><th></th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "\t<tr><th scope=row>19:44945208:T:G</th><td>19:44945208:T:G</td><td>9.576777</td><td>9.65202</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "A data.frame: 1 × 3\n",
+       "\\begin{tabular}{r|lll}\n",
+       "  & variant\\_id & z\\_imp & z\\_original\\\\\n",
+       "  & <chr> & <dbl> & <dbl>\\\\\n",
+       "\\hline\n",
+       "\t19:44945208:T:G & 19:44945208:T:G & 9.576777 & 9.65202\\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "A data.frame: 1 × 3\n",
+       "\n",
+       "| <!--/--> | variant_id &lt;chr&gt; | z_imp &lt;dbl&gt; | z_original &lt;dbl&gt; |\n",
+       "|---|---|---|---|\n",
+       "| 19:44945208:T:G | 19:44945208:T:G | 9.576777 | 9.65202 |\n",
+       "\n"
+      ],
+      "text/plain": [
+       "                variant_id      z_imp    z_original\n",
+       "19:44945208:T:G 19:44945208:T:G 9.576777 9.65202   "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "'19:44945208:T:G' %in% ov\n",
+    "imp_data %>% filter(variant_id == '19:44945208:T:G')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8dbb899-c8f7-45d1-b4f5-10faed86432e",
+   "metadata": {},
+   "source": [
+    "## Analysis under +- 50kb region"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "f43430f3-c8d7-4c44-b2c4-fd9aac978234",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "'chr19:44855791-44959393'"
+      ],
+      "text/latex": [
+       "'chr19:44855791-44959393'"
+      ],
+      "text/markdown": [
+       "'chr19:44855791-44959393'"
+      ],
+      "text/plain": [
+       "[1] \"chr19:44855791-44959393\""
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "start.reg=44905791-50000\n",
+    "end.reg=44909393+50000\n",
+    "reg=paste('chr19',start.reg,end.reg,sep='-')\n",
+    "association_window = paste0(\"chr19:\", start.reg, \"-\", end.reg)\n",
+    "association_window"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "e06e6a52-063f-47f2-8252-843d3a22f9a8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Taking input= as a system command because it contains a space ('zcat /mnt/jast/hpc/gaowang/users/xc2270/colocboost/pipeline/sumstat/EADB_core.tsv.gz | head -1 && tabix /mnt/jast/hpc/gaowang/users/xc2270/colocboost/pipeline/sumstat/EADB_core.tsv.gz 19:44855791-44959393'). If it's a filename please remove the space, or use file= explicitly. A variable is being passed to input= and when this is taken as a system command there is a security concern if you are creating an app, the app could have a malicious user, and the app is not running in a secure environment; e.g. the app is running as root. Please read item 5 in the NEWS file for v1.11.6 for more information and for the option to suppress this message.\n",
+      "\n",
+      "Region chr19:44855791-44959393 include 917 in input sumstats.\n",
+      "\n",
+      "42140\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "63.7703009697287"
+      ],
+      "text/latex": [
+       "63.7703009697287"
+      ],
+      "text/markdown": [
+       "63.7703009697287"
+      ],
+      "text/plain": [
+       "[1] 63.7703"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#get summstats\n",
+    "rss_input <- load_rss_data(\n",
+    "  sumstat_path = sumstat_path, column_file_path = column_file_path,\n",
+    "  n_sample = n_sample, n_case = n_case, n_control = n_control,\n",
+    "  region = association_window\n",
+    ")\n",
+    "message(rss_input$n)\n",
+    "# Preprocess the input data\n",
+    "preprocess_results <- rss_basic_qc(rss_input$sumstats, ldblock)\n",
+    "\n",
+    "#if zscore =Inf, transform as the max value\n",
+    "max(preprocess_results$sumstats$z[!is.infinite(preprocess_results$sumstats$z)])\n",
+    "if(any(is.infinite(preprocess_results$sumstats$z))){\n",
+    "message(sum(is.infinite(preprocess_results$sumstats$z)),' variants have infinite zscore, exclude them')\n",
+    "preprocess_results$sumstats<-preprocess_results$sumstats[!is.infinite(preprocess_results$sumstats$z),]\n",
+    "preprocess_results$LD_mat=preprocess_results$LD_mat[preprocess_results$sumstats$variant_id,preprocess_results$sumstats$variant_id]\n",
+    "}\n",
+    "\n",
+    "# Perform Slalom quality control\n",
+    "qc_results <- summary_stats_qc(preprocess_results$sumstats, list(combined_LD_matrix=preprocess_results$LD_mat), n = rss_input$n,\n",
+    "                             var_y = rss_input$var_y,\n",
+    "                             method = qc_method)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "7f97991d-84be-46ff-a120-77d1705a42bb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       ".list-inline {list-style: none; margin:0; padding: 0}\n",
+       ".list-inline>li {display: inline-block}\n",
+       ".list-inline>li:not(:last-child)::after {content: \"\\00b7\"; padding: 0 .5ex}\n",
+       "</style>\n",
+       "<ol class=list-inline><li>383</li><li>384</li><li>386</li><li>391</li><li>397</li><li>404</li></ol>\n"
+      ],
+      "text/latex": [
+       "\\begin{enumerate*}\n",
+       "\\item 383\n",
+       "\\item 384\n",
+       "\\item 386\n",
+       "\\item 391\n",
+       "\\item 397\n",
+       "\\item 404\n",
+       "\\end{enumerate*}\n"
+      ],
+      "text/markdown": [
+       "1. 383\n",
+       "2. 384\n",
+       "3. 386\n",
+       "4. 391\n",
+       "5. 397\n",
+       "6. 404\n",
+       "\n",
+       "\n"
+      ],
+      "text/plain": [
+       "[1] 383 384 386 391 397 404"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pp_cos <- which( paste0(\"chr\", preprocess_results$sumstats$variant_id) %in% variants )\n",
+    "pp_cos %>% head"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "e8f0b237-f5b1-4af4-99c1-dabf66ad0f2c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing single LD matrix...\n",
+      "\n",
+      "IMPUTATION REPORT\n",
+      "\n",
+      "\n",
+      "Variants before filter:                    23974\n",
+      "\n",
+      "Non-imputed variants:                      0\n",
+      "\n",
+      "Imputed variants:                          23974\n",
+      "\n",
+      "Variants filtered because of low LD score: 23758\n",
+      "\n",
+      "Variants filtered because of low R2:       23662\n",
+      "\n",
+      "Remaining variants after filter:           210\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# pp_cos <- which( qc_results$sumstats$variant_alternate_id %in% cos_idx )\n",
+    "sumstats_obs <- qc_results$sumstats[pp_cos, ]\n",
+    "qc_results$sumstats <- qc_results$sumstats[-pp_cos, ]\n",
+    "impute_results <- raiss(ldblock$ref_panel, qc_results$sumstats, ldblock$combined_LD_matrix,\n",
+    "              rcond = impute_opts$rcond,\n",
+    "              R2_threshold = impute_opts$R2_threshold,\n",
+    "              minimum_ld = impute_opts$minimum_ld, lamb = impute_opts$lamb)\n",
+    "ll <- list(summstats=data.table(impute_results$result_filter),\n",
+    "           sumstats_obs = sumstats_obs,\n",
+    "           outlier_number=qc_results$outlier_number)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "4095b61a-7592-44af-a796-0efeef842c02",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       ".list-inline {list-style: none; margin:0; padding: 0}\n",
+       ".list-inline>li {display: inline-block}\n",
+       ".list-inline>li:not(:last-child)::after {content: \"\\00b7\"; padding: 0 .5ex}\n",
+       "</style>\n",
+       "<ol class=list-inline><li>28</li><li>3</li></ol>\n"
+      ],
+      "text/latex": [
+       "\\begin{enumerate*}\n",
+       "\\item 28\n",
+       "\\item 3\n",
+       "\\end{enumerate*}\n"
+      ],
+      "text/markdown": [
+       "1. 28\n",
+       "2. 3\n",
+       "\n",
+       "\n"
+      ],
+      "text/plain": [
+       "[1] 28  3"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table class=\"dataframe\">\n",
+       "<caption>A data.frame: 6 × 3</caption>\n",
+       "<thead>\n",
+       "\t<tr><th></th><th scope=col>variant_id</th><th scope=col>z_imp</th><th scope=col>z_original</th></tr>\n",
+       "\t<tr><th></th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "\t<tr><th scope=row>19:44939092:T:C</th><td>19:44939092:T:C</td><td>9.764637</td><td>9.361135</td></tr>\n",
+       "\t<tr><th scope=row>19:44939831:G:C</th><td>19:44939831:G:C</td><td>9.838674</td><td>9.337308</td></tr>\n",
+       "\t<tr><th scope=row>19:44940247:A:G</th><td>19:44940247:A:G</td><td>9.751125</td><td>9.281704</td></tr>\n",
+       "\t<tr><th scope=row>19:44941309:G:T</th><td>19:44941309:G:T</td><td>9.677477</td><td>9.277907</td></tr>\n",
+       "\t<tr><th scope=row>19:44943014:C:T</th><td>19:44943014:C:T</td><td>9.707709</td><td>9.180963</td></tr>\n",
+       "\t<tr><th scope=row>19:44945208:T:G</th><td>19:44945208:T:G</td><td>9.608020</td><td>9.652020</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "A data.frame: 6 × 3\n",
+       "\\begin{tabular}{r|lll}\n",
+       "  & variant\\_id & z\\_imp & z\\_original\\\\\n",
+       "  & <chr> & <dbl> & <dbl>\\\\\n",
+       "\\hline\n",
+       "\t19:44939092:T:C & 19:44939092:T:C & 9.764637 & 9.361135\\\\\n",
+       "\t19:44939831:G:C & 19:44939831:G:C & 9.838674 & 9.337308\\\\\n",
+       "\t19:44940247:A:G & 19:44940247:A:G & 9.751125 & 9.281704\\\\\n",
+       "\t19:44941309:G:T & 19:44941309:G:T & 9.677477 & 9.277907\\\\\n",
+       "\t19:44943014:C:T & 19:44943014:C:T & 9.707709 & 9.180963\\\\\n",
+       "\t19:44945208:T:G & 19:44945208:T:G & 9.608020 & 9.652020\\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "A data.frame: 6 × 3\n",
+       "\n",
+       "| <!--/--> | variant_id &lt;chr&gt; | z_imp &lt;dbl&gt; | z_original &lt;dbl&gt; |\n",
+       "|---|---|---|---|\n",
+       "| 19:44939092:T:C | 19:44939092:T:C | 9.764637 | 9.361135 |\n",
+       "| 19:44939831:G:C | 19:44939831:G:C | 9.838674 | 9.337308 |\n",
+       "| 19:44940247:A:G | 19:44940247:A:G | 9.751125 | 9.281704 |\n",
+       "| 19:44941309:G:T | 19:44941309:G:T | 9.677477 | 9.277907 |\n",
+       "| 19:44943014:C:T | 19:44943014:C:T | 9.707709 | 9.180963 |\n",
+       "| 19:44945208:T:G | 19:44945208:T:G | 9.608020 | 9.652020 |\n",
+       "\n"
+      ],
+      "text/plain": [
+       "                variant_id      z_imp    z_original\n",
+       "19:44939092:T:C 19:44939092:T:C 9.764637 9.361135  \n",
+       "19:44939831:G:C 19:44939831:G:C 9.838674 9.337308  \n",
+       "19:44940247:A:G 19:44940247:A:G 9.751125 9.281704  \n",
+       "19:44941309:G:T 19:44941309:G:T 9.677477 9.277907  \n",
+       "19:44943014:C:T 19:44943014:C:T 9.707709 9.180963  \n",
+       "19:44945208:T:G 19:44945208:T:G 9.608020 9.652020  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "z_imp <- impute_results$result_filter %>% filter(paste0(\"chr\", variant_id) %in% variants ) %>% pull(z)\n",
+    "names(z_imp) <- impute_results$result_filter %>% filter(paste0(\"chr\", variant_id) %in% variants) %>% pull(variant_id)\n",
+    "z_original <- sumstats_obs %>% pull(z)\n",
+    "names(z_original) <- sumstats_obs %>% pull(variant_id)\n",
+    "ov <- intersect(names(z_imp), names(z_original))\n",
+    "imp_data <- data.frame(\n",
+    "    variant_id = ov,\n",
+    "    z_imp = z_imp[match(ov, names(z_imp))],\n",
+    "    z_original = z_original[match(ov, names(z_original))]\n",
+    ")\n",
+    "imp_data %>% dim\n",
+    "imp_data %>% head"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "f4cd3106-dde5-4ba2-98ae-3c71e3eeab30",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA0gAAANICAMAAADKOT/pAAADAFBMVEUAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACz\nMPSIAAABAHRSTlMAAQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyAhIiMkJSYnKCkq\nKywtLi8wMTIzNDU2Nzg5Ojs8PT4/QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW1xdXl9g\nYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXp7fH1+f4CBgoOEhYaHiImKi4yNjo+QkZKTlJWW\nl5iZmpucnZ6foKGio6SlpqeoqaqrrK2ur7CxsrO0tba3uLm6u7y9vr/AwcLDxMXGx8jJysvM\nzc7P0NHS09TV1tfY2drb3N3e3+Dh4uPk5ebn6Onq6+zt7u/w8fLz9PX29/j5+vv8/f7/qVjM\n+gAAAAlwSFlzAAASdAAAEnQB3mYfeAAAIABJREFUeJzt3QmcVXP/wPHfbE2LNO0riVRa0Wix\ntEmlSAjhkSVrPJaoLJX5UxEJJZJKskQ8eFqUhMpWhOopoT3RZmaaata7/P7n3HtnzEzjzp3O\ntzn9zOf9ej33nLnzu3O/r577MXPP3ZQCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgGNPm7aAUdq43UxREjVgmES3qynC\n2bqc2yMAJVFOn+32CEUgJBiGkAABhAQIICRAACEBAggJEEBIgABCAgQQEiCAkAABhAQIICRA\nACEBAggJEEBIgABCAgQQEpCn7sNzPn3hwiO5JCEBuS7cv37yYx9kv3sEtz5CAkIapY+JtjbN\nf3+25JclJCBk4tfB7SXZCSW+LCEBIT8+ENzGZfYs8WUJCQjZdFNoZ+8VJb4sIQEhS8cGt9V8\nHUp8WUICQu77I3jf6NGdMSW+LCEBIRXWftdKqYoPe/qX/LKEBOSqPU/v2+DZc9URXJSQgL80\nvuK2ThWO5IKEBAggJEAAIQECCAkQQEiAAEICBBASIICQAAGEBAggJEAAIQECCAkQQEiAAEIC\nBBASIICQAAGEBAggJEAAIQECCAkQQEiAAEICBBASIICQAAGEBAggJCC8k//vg8UTzi1mESEB\nYQ3MXPXc2IW+F6LCriIkIJz2nrvszdn77w+7jJCAcN6fE9zeuTdGdZy8bNnkjkUuIyQgnH0D\ngtu6usUY7/yRI+d7xxS1jJCAcLJ6BLfxOinzAnunR+a1RSwjJCCcTYOD2xZ6w+jg3pi1RSwj\nJCCc8f+LD2xf+VG3C57TTlc+fBkhAeHU2LH4ZKUSJmT3002D5zTVdQ9fRkhAWCd/oX/f6NvW\nPTa9b/CMS9JjD19FSEAR6l8+5PL69k6rGWuSN/y3e5xSs5fG2GfELJtdxHpCAg5T7nlP8qpk\nz/Pl1NXZC+++6tEtGxso1Wjfh42VOvXDfY2KugQhAYXN2NXLOu21a/rJWUPsrystXWqdNl+h\nk5P1N6cVdQlCAgo7w9c+sG3vm/lt8JxT/W0Cm8svb1L0RQgJKOzRFaGdlZtDjx2pLTeFvwgh\nAYW9/FZo561dj4T21g8OfxFCAgp76uPQzuL/vRPcOS6zR/iLEBJQWJ+MOoFt3YwROWcE9sb+\nHh/+IoQEFBb93fLq1qb68m+jZ/05qF5sixc9fYq5CCEBh6m/ev87497Z/2N9FfNwqvbrtV2L\nuwQhAYcrd+1LH710beBWGHNqp1oRXICQAOcICfgbdS8b0v+ECNcSElCk2PE5Kav+9L5YzOG6\nEEICivTi3ous0/N3vhnRakICitLc1ymwPcNb9NsGFUJIQFGGrw7tLBsbyXJCAory/PuhnRmv\nRbKckICiPLYstDP3+UiWExJQlPOzg0e+axy4PJLlhAQUJerLb+wnNFT9dE0Rb3VyOEICilTn\nu7R3x72dsq5hRKsJCSha3IDJH00ZGNnjsYQESCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQE\nCCAkQAAhAQIICRBQyiGddNtzr89+ZUSvYjohJBimVEOq8rYO2Xd72IWEBMOUZkjRy/WSG7vf\nsmX8Wff8pMeEW0lIMExphtRNj7M3Jx46X8W97W8cZiUhwTClGdIDunpg++FbStXRhf+4S5j0\ncp4FhASzlGZIw32VAtu5XyoV5Rle6LvVX5+TZ5U+rtSmAgSUZkh9dOBzOBsdeFuprvrqMCtv\nIySYpTRDitvsmdy3+wO79AWq959px4dZSUgwTKke/m61zT70nX2XUnf/0SncQkKCYUr3Adn4\n/qPH3VHP2qkW/mACIcEwx+ZThAgJhiEkQAAhAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAh\nAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAh\nAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAh\nAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAh\nAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAh\nAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAh\nAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAh\nAQIICRBASIAAQgIEEBIggJAAAYQECHAS0rQC+gpORUgwjJOQdAFJEVyi79SJXZW6dUPW1qTY\ncOsICYZxElKzAmoUf4GRdnB336DTt+ToV8MtJCQYRuw+0hOJxS6pk/Fp1w4TU9e+GKsqv6Wb\nhFlJSDCM85BiqyQkJFRN3D+82JUDsqtbp9/vL2+dHu+9JcxKQoJhnIbUcrkvdB+pX7Frh222\nT6f/EPhixyOFvttg3eY8+wgJZnEYUtxG78rNexf/qhdeXfziW1Ps03nb7NOo9HsLfTf+xlvz\nvEFIMIvDkC7WPdTo+Up1+7l38Yvb65uV6piTdqG1f53uGmYlf9rBMA5Dus/6JWOHpLocqln8\n6s/0uu89i5/Onvrwm74N0WEWEhIM4zCkIfuUGrXc3tt5Y/Gr68z3Zb1bveIn1j2qzc3DLSQk\nGMZhSP11K3Vrmn2r3zkskvVxgd9DiQO6xoVdRkgwjMOQKqWltGuqP+7SdqK+TGokRUgwjtPD\n3z33na1eso9+fx/+d0zJEBIM4/gB2bh4FXX5y1MHl5eZJ4iQYBheRgEIcBxSnR6X9w8Iexiu\nhAgJhnEa0lO+kryMIlKEBMM4DKmdXjtmyL0BHaRGUoQE4zgM6a4d8VKT5EdIMIzDkB5YKDVI\nAYQEwzgMqevWKKlJ8iMkGMZhSFHvjT8af9sREgzjMKTO4/fvXvRGAE8RQhnmMKSkkr2LUKQI\nCYZxGFL1hg1yHS81kiIkGIenCAECnIQ0pZG6aEqeiwSnIiQYxtE7rXbgPhIQ4OidVsurGiV6\np9WIERIMw30kQIDDkJr27hXSs1M9qZkICcaRexxJ689OEhqKkGAahyG1Gbor+c3H/m/Wvu2P\njFngXx8jNBUhwTAOQ4r+bE7gJl/pnTlKDdQ9ZYYiJJjGYUi9MyoHdyqnn6OiDt0vMZIiJBjH\nYUjDd+Xu7bAi2jXU+UABhATDOAxpsG4f3Gmp71Vn6islRlKEBOM4DKlhdvKIbi1bdHpgl79l\n671pUjd/QoJhnD4ge83B4KHvnCGqdXIvoaEICaZx/MyG6tdPmPX6pDtOUCq2osxIipBgHJ4i\nBAjgZRSAAF5GAQjgZRSAAO4jAQKcfobs2lipSfIjJBjGYUi3+xKkJsmPkGAYhyFVWTWrstQo\n+RASDOP0nVaf+Dlj2RzeaRVlHe+0CghwGFLNJifxTqsAh78BCc4/jPmBOUuXzr5L9uAdIcEw\nTkPqcyB4D2l3e6GBAggJhnF6+Dt1150ta9VqPWTfb+WlRlKEBOM4DOlK3Ta4k6j7SowTQkgw\njMOQHvwjd2/7MOfD5CEkGMZhSEP35+799oDzYfIQEgzj9H3tdOgJDT31hRLjhBASDOMwpLhN\nGc/1TTzrkkmZv8RJjaQICcZxevi7+a/Bw98/NREaKICQYBjHD8jGXTJu1mtP9pF9WRIhwTCi\nTxF6aIbQDyIkGEY0pOeWCP0gQoJhCAkQQEiAAEICBBASIICQAAGEBAggJEAAIQECCAkQIBrS\nkMlCP4iQYBiHITXpHR/aG9LF+TB5CAmGcfxOq6tPC+7tTHI+TB5CgmGchuTxZtwe2NuZJDBN\nLkKCYZyGtPOcbfqD6oqQULY5DklVma13diMklG3OQ1Lq+oO+J+N2JonME0RIMIxESOqUlfrb\n1CSReYIICYYRCUnFjvXx+UgoyxyG1PrS0E6X9wcITJOLkGAYkWc21O96ZrTzn5IPIcEwjkIq\n99hH9umrWuv1p4qNpAgJxnEU0gK9OUqp0fqbweMyfoqRG4qQYBonIXXUr1j1xO//paJSA3R3\nwakICYZxEtIdXvsDmHto+wNdyvmGiM1ESDCOk5C253xp2aLX2Rvv9i/lpiIkGMZJSHOz7rX8\nscc+vTdn7r1yUxESDOMkpIG6mlL1vdPt/Zp6oNhMhATjOAmpsXdmreZf6fPs/Ym6udhMhATj\nODr8Pcn+ZKRnrJ3ET/X7YiMpQoJxHIUUdfX0yYHnCPX0vFFBaiIbIcEwMm9+Ur6WeiJR4Ofk\nIiQYxnlIsVUSEhKqJu4fLjJPECHBME5DarncF/wQWd1PaCIbIcEwTj/VfKN35ea9i3/VC6+W\nmshGSDCMw5Au1j3U6PlKdfu5t9RENkKCYRyGdF+KCoSkuhyqKTSRjZBgGIchDdmn1Kjl9t7O\nG2UGCiAkGMZhSP11K3Vrmn2r3zlMaCIbIcEwDkOqlJbSrqn+uEvbifoyqZEUIcE4Tg9/99x3\ntnrJPvr9fZzQRDZCgmEcPyAbF6+iLn956uDyMvMEERIMI/r5SGIICYZxGNLAKaGd6B19BKbJ\nRUgwjNN3Wl0d2jkui/dsQBnmKKQVK3amrwhYuVffIDYTIcE4jkIaNS/ZnxW0d1Y5uaEICaaR\n+tNOFiHBMA5Dqpf3Tg28sA9lGS/sAwTwwj5AAC/sAwTwwj5AAC/sAwTwwj5AAC/s+2epMvT9\nH9+7j3+9UscL+/5RWuzY+ty9E3/bdIrbg5Q5vLDvnyR+03v268IqfbQ21u1Ryhpe2PdPcnXq\n8YFtjfSLXZ6kzOGFff8kkz4I7SwZ6+ocZZCTkHrl17up4FSEdGRmvBba+c9EV+cog5yEpAtI\nKnZ9QsPoCH8yIUUk6pw7R12R//G7R1eEdtbf78Y8ZZmTkEZYnjy4/sWkx2ds3/dAm2LXJ+lv\nWkX2kwkpEo1WeNYt/zP97r/Oae3rEthe5Gnszkhll9Pn2n07JrCNmbiy+KN2SXqzZ0KVSH4s\nIUWg8uYlDZSKvinr1r/Oez7lX/GqwqADY9wbq4xyGFLfjJjgTsXs4o8TJemEcZ5990bw2X6E\nFIEHt1UMbO9Jjs87L2bkIe9Ob9rQKLeGKrMchjT8t9y9CF6PlKTLq+aLdcqExCL/f65cNc99\nhFS8Lx4Pbo/zdM53buVzru3IP17pcxjSnbptcOc8fVexi+2QlOr6uda75o0bdlah757iz3/o\norKTqcqGjTeHdnZd5eocsDkM6aTs5KRebRN7JaVEcPc2GJJSrZ7+taijfM3b5hnDb6TirXw4\nuC2XdYG7g0A5f0D2yrTgb5CMm4pfmxuSpW6PQe3CrOQ+UgSeXBN8NGFABr++3ef4mQ0J1z0z\na9ZzN9eKYGm+kIpBSBGokzLN/vc8J/kxtyeB8FOEHpoR9tsjsuLDfv8vhBSJDr/vfvflr/0v\nRvowN44i0ZCeWyL0gwgpIsfd9MKbI9q6PQVshGSgCi2ruT0CCiEk00R1/dKr9eZBSp3c5/za\nbk+DEEIyS98vMnX6/NatH86YuUqnZfk/aHBaOw7aHQMIyShP+vb4PV5Pzj3qVv1x0/5LD9oP\nPfgXS76EBUeEkExytd6xz794feYu/6TPdk98PvuTXSkH0tZfOD+1hduTlXmEZJC41D9e2bNG\nRT2d6s/2v7rer1N8fl9O8qLo/y51e7Qyj5AM0sf3RObUtVZQ21J/1Z/4frsw07vyZ71Ojzzd\nP/LVJV8ve6lz8T8DRwchGWTUgUm6p6eOil6js7VP7/TrH77yar/W2/Sf/gz/t/O8E3n9hEsI\nySBjfl+mK675T+y4bD3U7/f4/amDfjiUrn2Zfu3trzrvnnzugTvdnrGsEg1pyGShH0RIRbrx\nT6/v7BZ7/udLT1un/f5V+rsNv3su0f6s/foL69tdfKcM3c6vJHc4Dqn16A+XL33vEdm39iSk\nItU4sMS3tcu56/w6OfvZbO3xb9D+YXV19nde/0b7+5vuaKJPcHvIMsppSKNCL8fz3CM0UAAh\nFW2QZ4nX+jPO/9mOz8t9m7lbZ2rvp3v82Z6DOsf+TfR5Ui3dvNgfgqPBYUit/T9ccWqNWi1u\n3u47TWokRUh/69KNgf9spT5RXt2nH87waesvvJzsnKGpXvsp4Bv+fZ73eLdHLKMcfz5SQnDn\nFL/kryRC+lv1zjv1Sl8Ta6dqTo6VVLrOTkvz1l2ZUU6pRH+L/y5ye76yymFIwz7P3ds61Pkw\neQgprEWr61unr+usT7O1VdOidStS9n/crOWW918/0NLt2coqp2/HtTG0E39Q8o0DCCmsal8c\nev+p2TnZvvXzMv27P1n1SI73691aZ+k1iW6PVmY5fYPIrx8vZ2/Lv/yx5Os0CSm8mMufX/CK\nr0+zuyY98VGy1jsfvXT0zGcevrIlx75d4zCkri9lJy96feai1AOvvjJt2rS+QlMRUvFq69Dh\nnQ4c8j4GOAwpqaRvpB8ZQipeOc/5wZ1OvoruTgLlOKQ6zZvlV0NoKkKKwCevB7czlrk7B2x8\n0JixOuaMjFMq9iHPeW5PAkIyWb/U3R8t2LW/v9tzQDkPqc2M7zb8HFD8e39HjpAiUuW6cU9d\nX9XtKWBzGFK9FJ31x86AIVIjKUKCcRyGNCiz59F47IKQYBinTxH6TGqQAggJhnEYUq+fpAYp\ngJBgGIchRS8aezQeDSQkGMbpUbvme9K+XxIwUGgiGyHBMA5Dqr9f/OlBNkKCYRyGdLt3UM2j\n8PE8hATDOAzpweVSgxRASDCMw5Au+VFqkAIICYZxGFLsknuOxgcvEhIM4zCkzhPSti94I+Ay\nqZEUIcE4ci/sSxKayEZIMIzDkKo3bJBL8g3VCAmG4fVIgAAnIU1ppC6akuciwakICYZxEpLu\nwH0kIMBJSM3Kqxryb3xiIyQYhvtIgABCAgQQEiCAkAABhAQIICRAACEBAggJEEBIgABCAgQQ\nEiCAkAABhAQIICRAACEBAggJEEBIgABCAgQQEiCAkAABhAQIICRAACEBAggJEEBIgABCAgQQ\nEiCAkAABhAQIICRAACEBAggJEEBIgABCAgQQEiCAkAABhAQIICRAACEBAggJEEBIgABCAgQQ\nEiCAkAABhAQIICRAACEBAggJEEBIgABCAgQQEiCAkAABhAQIICRAACEBAggJEEBIgABCAgQQ\nEiCAkAABhAQIICRAACEBAggJEEBIgABCAgQQEiCAkAABhAQIICRAACEBAggJEFDKIcVY/zvu\nqoeGdIsOu4yQYJhSDanR8uuU6vGntqw5OdxCQoJhSjOkuC3Z16h6hzImXHPTbP/62DArCQmG\nKc2Q+ukrlRqiu9n79+veYVYSEgxTmiEN9Vp3kSZuC+xX9g8t9N2Yi6/IM5WQYJbSDOnfOkGp\nEb8E9iv67iv03ZN2p+RJ15VLbSpAQGmG1FJPUqpFdnN7f6Q+N8xK/rSDYUr1qN0Uveyaxvdt\nvL7jFf/Vi8MtJCQYplRDih5xSIfMDlsKIcEwpfyAbJUBz7y3aP7M+5uGX0ZIMAxPEQIEEBIg\ngJAAAYQECCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAhAQIICRBASIAAQgIEEBIg\ngJAAAYQECCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYR0mHoV3btumIqQCjrhzVTt23BblEtX\nD1MRUgFN937Zv2n7Rw5Od+fqYSxCKmD5ghh7k5jd153rh6kIKb9T9WnBnekfunL9MBYh5XfJ\n/tDOLb+6cv0wFiHld/GB3AF+duX6YSxCyq+RbhPcef1dV64fxiKkAhZ/Hm9vOnl6uHP9MBUh\nFdBwx5pB7Xo+nTXBnauHsQipoJqTt+r0b65y6dphLEI6TMVo964bpiIkQAAhAQIICRBASIAA\nQgIEEBIggJAAAYQECCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAhAQIICRBASIAA\nQgIEEBIggJAAAYQECCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAhAQIICRBASIAA\nQgIEEBIggJAAAYQECCAkQAAhAQIICRBASIAAQgIEEBIggJAAAYQECCAkQAAhAQIICRBASIAA\nQgIEEBIggJAAAYQECCAkQAAhAQIICRBASIAAQgIEEBIggJAAAaaHdNr1D19R76jOAkTA7JCq\nvKu3frk3e2z0UZ4HKIbRIUV99tMZ1mm/lCeO9kBAeEaH1C/9xMD24pwTjuo4QHGMDmnanNDO\njpuP4jBA8YwOacFToZ3lI4/iMEDxjA7pjVeb3z9t3NXl1Ya7jvZEQFhGh3RLun/16x8lb71a\ntzzaEwFhmRXSgAXbty8YkPflKN+K45Wq9KF3bmkNBhTNpJBi3kx/YeDAyelvhh42qnRo2M/J\n701d5c2YXKrTAYcxKaR7Ulrbm9ap9wS/7p5dPv6GH33Z23N8j8eU4nTAYUwKadOw4Hb4puD2\nqt1Kzdh9cZS6eXfys6U2G1AEF0I6b8ayhUl1wi4pMqQEfUZw5wydENh2yamU6Gtn7SR9db63\nmfCUQEmUZkijvPHW6TBtS24fbmWRIdXWoVhO07UD2/Kpd4z+wt5uGqnWDhUeFiiJ0gwpSZdX\nqpX/9yvrNRuevr1cmJVFhhSTelVwZ0Bq6GjDXRnLXlWq1vwdVdR/JoqPC0Su1EN6THe092/T\nvcOsLPo+0pTVFe1NxTVTcs950Jux8NvMNU2U+vxx2VmBEin1kGbsCexX1Q8U+u7xo5/Ms6jI\nkGptXtn9+OMvWLm5Zt5Zt2U8O+wC6/dTvayeR29uoFilHtKY3YH9eP+QQt+tOXtOni/slYer\n/bZXa+/s2n+dE7f+o8rWpuqyb3lJEtxU6iF11Y3t/d76sjArz9Z/cw+qwplnVihwxim/7Jnx\n6GvJaxtIDQkcidIN6bP3po1PnWft9tuTXCnMyr8N6XAVb5u5dPpN8c6nAxwozZDu3p1lH/le\np1RUVk7/cCtLEBJwLCjlB2Tj6zRrbx+1G9Em7DJCgmGOzacIERIMQ0iAAEICBBASIICQAAGE\nBAggJEAAIQECCAkQQEiAAEICBBASIICQAAGEBAggJEDAsRlSogYMk+h2NUVp0/Zw/jH/ct+y\n5W5PYBmtr3N7BMueV9yewPLuL25PYPm37te2bfiXqh5L/F3dnsAyY6bbE1g66WPhPZM2DXJ7\nAsuIL9yewNIg+IY+piCkXISUh5BKjpByEVIeQio5QspFSHkIqeQIKRch5SGkkiOkXISUh5BK\njpByEVIeQio5QspFSHkIqeQIKRch5SGkkiOkXISUh5BKLusctyewTJnq9gSWDjlRbo9g+ek6\ntyewDPvU7QkstfSJbo9QEo2OhVtP1apuT2CJauT2BLYT4tyewFKxjtsT2E52ewAAAAAAAAAA\nAAAAAAAAAAAAAAAUVK5LkOtvsHxyhxNcnqBT6J+iS3l356ie2NTlCSxxbTrUdHWAk7pUD+1V\nPCOxiqujRKRx6B3/l7g7xhk/WjN87e7LuLJyP/3gJDenOP1za4KMCRXdnEFFPZSmte/dBPcG\n+HemviiwFz02Xeucqe7/p6UYiXpWL5u7H53RKGXXoHOHZP4a6+YQFwT+IXpt2unmjbhB2p6r\nGrZ8Qb/r4gxKjdI/Xtn5Bf2JW9dfd5FndSikMXpur67T9WtujRKp7vpet0ewzPa2tk5veecY\neGXx9bqfm1c/XN9mb9b63XzlfaX0PZWtzau6h0sDTNra4cFgSDWyvrPfj+ZDf3OXRolUf32D\n2yMoVTnrA7dHyFXtzwWuXv/juqe9mafruzjEufole3O6nuLSAH2qqFBIA4P/YemtR7g0SqRu\n1v1OvPjaM9wdopu+W7Xu1yne3SkCJuec6ur1X6ifsk4r/LbFzTek6aOT7E0F/Y17M4RCmhD8\nvL5a+j33RonI/fpLr3Xv9qsGbg5xq771C2uIP853c4iAxp5JLk8w0zvt+sErD7r6VoNnBe+S\n1NDb3JshFNIcXc/eRHlWujdKRB7XP1za6Kw39OoYF4cYpvdNalz7+rSDDV0cImCmx80/qWx1\n5tpH7Ya4+X+Hitt7yH4sYoze7d4MoZDm62qBLw+uc2+UiFSsEThStjB0jMQdw/RiezNYj3Fx\nCFvt7HdcnqDRH7/0SDjhPs9cV6e4We8aeesHm7ZvcW+EUEgf6lqBLzN/cG+UkhikR7p47bcH\n70qeoue7OIRtqL7Q5Qlm6jPtzfO6u6tjXPeLPvRW3T+/dm+CUEjTdVN7U9HtBzojNdDVkLrq\np+1NXb3QxSFsKw65fcBjXXbgKMNA/YDLg8QpdYJrR+1UXkjDdF97c6Z2+75rcZ5eGHjMeIru\n7+IQFQ6ttm8+F7n9r1XZ+5m7Ayj1vQ48M2aYvtPNKRoHfi0+pPu4N0IopDODMT/q6l2PSIzX\nL5ZT6hLPHxXcnOJZ+xdinTW6o5tD2I+fTHR3APvgz6Ropapt8p7i5hQr09so1eHQGhc/myMU\nkvo6u4tSpx/4xdUnvUSg0jd6z7KNOuVsd6f4Wm9dfkA/5uoQ9h9UD7k8gTruK73hjfdTfPe4\nOsU5GZ4vvvHtaurW9S9bsWKH/nnFiiSlmuz2f/e1N/VMt0aJWMyAaYs+eKiWy1PE3fLu4ldc\n/5imfksvdXsEFXvNzMULxp/u8hRNx8+b+0j14tcdJYuXBj1i7dcYNW/+4/VcGwUAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADPa2rlPCS3hXFLfiuFYHB9cVvEbg\nmNf3wUolvEShkKIWtSsrDDIEAAADnElEQVT4/WozvNqy7O8+T7nk1wj8AxUKqYnuVfD7i3yP\nnXtg8KOen+NKcSjAXc27lFPNO6uoFu2qWF81Taxsn9nSOqNZx8P/OqvavnlUKKS4xh1OirG2\nrR7Vw7pUyXdGDf2WUvu7q8d1P9W+S0DbI79GwAz2PZbXdIv1OTrjhpN/zNGZg6wz39Ptf/Zp\n/zvlC64d69F64xkeO6R79lh/vW3rq9R8+8+4c/Od0UC/Egip2mnRapMOWHXE1wgYwr5ZT9cr\nLohulZy2sn/sSVuyq9pnbhkQV/1l/UyBpTfoVeeceucvdkiX6aWdm/T+1dNMVUrSlyfE5Dsj\net+fzeyQbCc2trypxxzpNQKmsG/W0/Qj1t5MPck6Ha2722eOt3Zjd6XG5l/6na++dXqftkLq\nMbaxtXuVflCpBwP3kfKdcZUnc3bmNXmXOt+/ssBPKck1AqYI3qytv83UWN3fOh2sr7DPPN/+\n3vu6Wb6V8d619qaRDtxHqnJWt+536wm5IeU7Q3Wcl6311seqBM6u/vuBQofvIr9GwBjBm/Wp\n1l6SPs86vVkPsM9sYn/vRd0538qGeqG9ibFDqjbHq7MPZejnckPKd4al0oEFO/TmBHv3Qz3w\niK8RMEbwZm3/XZYU+C0RulmfaH/vheCviZDGeq69ifJbIc3VT9dWqsNfIeU7w7a/e8wzeqy1\nc4d9DO9IrxEwxt/crNvY33tD5z9wXVsvszc1rN9ICf419u5FeSHlP6OhChy1i0lbrNRpGVur\nHPk1Asb4m5v1jfb3Vvsq51+ati/KOr3YCqmh/sA+49W8kPKdMVU3CoQUnf6pil/tPdvJNQKm\n+Jub9dqaSvXRSwotHazUcSt8K1Rs1rZySl29Wr+m1L36OpX/jAv1kgQrpKhRerh6To9ydI2A\nKf7mZv3c7nfmZaefWWBpszT/iv/sfmbfSqWe0Wtf/nL7SSkZr9TorPfN65f/jCf0/s9yvt2i\nl1Zo7PfNfsN2pNcImGLU0mpq6FL7AaIblrayTvss7WbfrOtf8ubHL55WaG3jiR/PuU69PVWp\nqFvmzEuqqS6c91aCumvB6x0KnHHmhA88q2b9K0Y1XhpyxNcImOxt3cDZDwg9s6EUrxE49ji+\nWZ9btbSvETj25N2sa/f7S/0j/3nF/xhCwj/QqKU1gzu9vX+58sh/XvE/Ju8aAQAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIOL/AeDB34fxogYSAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "plot without title"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "height": 420,
+       "width": 420
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot(imp_data$z_imp, imp_data$z_original)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "c25a8973-b774-4c73-a1c9-7c24940369a2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "TRUE"
+      ],
+      "text/latex": [
+       "TRUE"
+      ],
+      "text/markdown": [
+       "TRUE"
+      ],
+      "text/plain": [
+       "[1] TRUE"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table class=\"dataframe\">\n",
+       "<caption>A data.frame: 1 × 3</caption>\n",
+       "<thead>\n",
+       "\t<tr><th></th><th scope=col>variant_id</th><th scope=col>z_imp</th><th scope=col>z_original</th></tr>\n",
+       "\t<tr><th></th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "\t<tr><th scope=row>19:44945208:T:G</th><td>19:44945208:T:G</td><td>9.60802</td><td>9.65202</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "A data.frame: 1 × 3\n",
+       "\\begin{tabular}{r|lll}\n",
+       "  & variant\\_id & z\\_imp & z\\_original\\\\\n",
+       "  & <chr> & <dbl> & <dbl>\\\\\n",
+       "\\hline\n",
+       "\t19:44945208:T:G & 19:44945208:T:G & 9.60802 & 9.65202\\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "A data.frame: 1 × 3\n",
+       "\n",
+       "| <!--/--> | variant_id &lt;chr&gt; | z_imp &lt;dbl&gt; | z_original &lt;dbl&gt; |\n",
+       "|---|---|---|---|\n",
+       "| 19:44945208:T:G | 19:44945208:T:G | 9.60802 | 9.65202 |\n",
+       "\n"
+      ],
+      "text/plain": [
+       "                variant_id      z_imp   z_original\n",
+       "19:44945208:T:G 19:44945208:T:G 9.60802 9.65202   "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "'19:44945208:T:G' %in% ov\n",
+    "imp_data %>% filter(variant_id == '19:44945208:T:G')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35832798-7d02-4acc-a562-f8c9e201b494",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "R",
+   "language": "R",
+   "name": "ir"
+  },
+  "language_info": {
+   "codemirror_mode": "r",
+   "file_extension": ".r",
+   "mimetype": "text/x-r-source",
+   "name": "R",
+   "pygments_lexer": "r",
+   "version": "4.4.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
1. A larger merged set including 60 variants
2. RAISS imputation using a larger region
3. RAISS imputation using a smaller region (+-50 kb)

Conclusion: we did not see the difference between imputed and observed z-scores for this set on EADB GWAS